### PR TITLE
Bugfix: fix command handler

### DIFF
--- a/server_handler/internal/handler/handler.go
+++ b/server_handler/internal/handler/handler.go
@@ -65,6 +65,11 @@ func serverDown(ps pubsub.PubSubInterface) {
 }
 
 func command(ps pubsub.PubSubInterface, message string) {
+	if docker.VerifyIfContainerExists() {
+		log.Println("Container server donts exists")
+		return
+	}
+
 	commandexecuter.WriteToContainer(message)
 	msg := models.NewMessage(docker.GetZeroTierNodeID(c.ComposeContainerName), []string{"commands"})
 	ps.SendMessage(msg.ToString(), c.SenderChannel)


### PR DESCRIPTION
## What was done
- Create a public function that checks whether a container exists.
- Avoid running a command if the container doesn't exist.

## Why was done
- Avoid sending a command to a container that doesn't exist, what crashes the program.

## How to test
- Run the program.
- Ensure that server is down.
- Send a Message across a command channel, with the tag command.